### PR TITLE
Add manifestation build directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 bin/
 obj/
 *.pck
+
+manifestation/


### PR DESCRIPTION
I did a manifestation build and then did a git push and didn't realize that manifestation folder was there. This will gitignore the manifestation folder.